### PR TITLE
Update hyper version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,9 +386,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ tempfile = "3.3.0"
 # cli feature dependecies
 rustls = { version = "0.20.7", features = ["dangerous_configuration"], optional = true }
 tower = { version = "0.4.13", optional = true }
-hyper = { version = "0.14.20", optional = true }
-hyper-rustls = { version = "0.23.0", features = ["http2"], optional = true }
+hyper = { version = "0.14.23", optional = true }
+hyper-rustls = { version = "0.23.1", features = ["http2"], optional = true }
 
 [build-dependencies]
 tonic-build = "0.8.2"


### PR DESCRIPTION
- when running the server in a docker container, all requests ended up with failure: `read_preface: invalid preface;`
  - a similiar issue to ours (for reference): https://issuehint.com/issue/hyperium/h2/548
- run the server as a non-root user for security reasons