### PR TITLE
Refactor messages, distinguish broadcast and unicast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "meesign-crypto"
 version = "0.3.0"
+source = "git+https://github.com/crocs-muni/meesign-crypto?rev=343fbbc#343fbbcb57c3efd0840716e41ddcbf4328cf7ca9"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,8 +957,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "meesign-crypto"
-version = "0.1.0"
-source = "git+https://github.com/crocs-muni/meesign-crypto?rev=92fbdc7#92fbdc78be45a93494edc826bddb5e939c8185cb"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tempfile = "3.3.0"
 lazy_static = "1.4.0"
 openssl = "0.10.60"
 sha2 = "0.10.6"
-meesign-crypto = { path = "../meesign-crypto", default-features = false }
+meesign-crypto = { git = "https://github.com/crocs-muni/meesign-crypto", rev = "343fbbc", default-features = false }
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tempfile = "3.3.0"
 lazy_static = "1.4.0"
 openssl = "0.10.60"
 sha2 = "0.10.6"
-meesign-crypto = { git = "https://github.com/crocs-muni/meesign-crypto", rev = "92fbdc7", default-features = false }
+meesign-crypto = { path = "../meesign-crypto", default-features = false }
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/src/communicator.rs
+++ b/src/communicator.rs
@@ -100,10 +100,9 @@ impl Communicator {
 
     /// Moves messages from incoming buffers to outgoing buffers
     pub fn relay(&mut self) {
-        self.output = (0..self.threshold)
+        self.output = self.get_protocol_indices()
+            .into_iter()
             .map(|idx| {
-                let idx = idx + self.protocol_type.index_offset();
-
                 let mut unicasts = HashMap::new();
                 let mut broadcasts = HashMap::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,15 @@ mod proto {
             }
         }
     }
+
+    impl ProtocolType {
+        pub fn index_offset(&self) -> u32 {
+            match self {
+                ProtocolType::Gg18 | ProtocolType::Elgamal => 0,
+                ProtocolType::Frost => 1,
+            }
+        }
+    }
 }
 
 lazy_static! {

--- a/src/protocols/frost.rs
+++ b/src/protocols/frost.rs
@@ -76,8 +76,7 @@ impl FROSTSign {
 impl Protocol for FROSTSign {
     fn initialize(&mut self, communicator: &mut Communicator, data: &[u8]) {
         communicator.set_active_devices();
-        let participant_indices: Vec<_> = communicator
-            .get_protocol_indices();
+        let participant_indices = communicator.get_protocol_indices();
         communicator.send_all(|idx| {
             (ProtocolInit {
                 protocol_type: meesign_crypto::proto::ProtocolType::Frost as i32,

--- a/src/protocols/frost.rs
+++ b/src/protocols/frost.rs
@@ -26,8 +26,8 @@ impl Protocol for FROSTGroup {
         let threshold = self.threshold;
         communicator.send_all(|idx| {
             (ProtocolGroupInit {
-                protocol_type: ProtocolType::Frost as i32,
-                index: idx + 1,
+                protocol_type: meesign_crypto::proto::ProtocolType::Frost as i32,
+                index: idx,
                 parties,
                 threshold,
             })
@@ -77,15 +77,12 @@ impl Protocol for FROSTSign {
     fn initialize(&mut self, communicator: &mut Communicator, data: &[u8]) {
         communicator.set_active_devices();
         let participant_indices: Vec<_> = communicator
-            .get_protocol_indices()
-            .into_iter()
-            .map(|idx| idx + 1)
-            .collect();
+            .get_protocol_indices();
         communicator.send_all(|idx| {
             (ProtocolInit {
-                protocol_type: ProtocolType::Frost as i32,
+                protocol_type: meesign_crypto::proto::ProtocolType::Frost as i32,
                 indices: participant_indices.clone(),
-                index: idx + 1,
+                index: idx,
                 data: Vec::from(data),
             })
             .encode_to_vec()

--- a/src/tasks/decrypt.rs
+++ b/src/tasks/decrypt.rs
@@ -101,7 +101,6 @@ impl DecryptTask {
             .map(|d| {
                 ProtocolMessage::decode(d.as_slice())
                     .map_err(|_| String::from("Expected ProtocolMessage."))
-                    .map(|m| m.message)
             })
             .collect();
         if messages.iter().any(|m| m.is_err()) {

--- a/src/tasks/decrypt.rs
+++ b/src/tasks/decrypt.rs
@@ -7,7 +7,7 @@ use crate::protocols::Protocol;
 use crate::tasks::{Task, TaskResult, TaskStatus};
 use crate::{get_timestamp, utils};
 use log::info;
-use meesign_crypto::proto::{Message as _, ClientMessage};
+use meesign_crypto::proto::{ClientMessage, Message as _};
 use prost::Message as _;
 use tonic::codegen::Arc;
 
@@ -96,7 +96,8 @@ impl DecryptTask {
             return Err("Wasn't waiting for a message from this ID.".to_string());
         }
 
-        let messages = data.iter()
+        let messages = data
+            .iter()
             .map(|d| ClientMessage::decode(d.as_slice()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "Failed to decode messages".to_string())?;

--- a/src/tasks/decrypt.rs
+++ b/src/tasks/decrypt.rs
@@ -7,7 +7,7 @@ use crate::protocols::Protocol;
 use crate::tasks::{Task, TaskResult, TaskStatus};
 use crate::{get_timestamp, utils};
 use log::info;
-use meesign_crypto::proto::{Message as _, ProtocolMessage};
+use meesign_crypto::proto::{Message as _, ClientMessage};
 use prost::Message as _;
 use tonic::codegen::Arc;
 
@@ -97,7 +97,7 @@ impl DecryptTask {
         }
 
         let messages = data.iter()
-            .map(|d| ProtocolMessage::decode(d.as_slice()))
+            .map(|d| ClientMessage::decode(d.as_slice()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "Failed to decode messages".to_string())?;
 

--- a/src/tasks/decrypt.rs
+++ b/src/tasks/decrypt.rs
@@ -96,17 +96,10 @@ impl DecryptTask {
             return Err("Wasn't waiting for a message from this ID.".to_string());
         }
 
-        let messages: Vec<_> = data
-            .iter()
-            .map(|d| {
-                ProtocolMessage::decode(d.as_slice())
-                    .map_err(|_| String::from("Expected ProtocolMessage."))
-            })
-            .collect();
-        if messages.iter().any(|m| m.is_err()) {
-            return Err("Failed to decode messages".to_string());
-        }
-        let messages = messages.into_iter().map(|m| m.unwrap()).collect();
+        let messages = data.iter()
+            .map(|d| ProtocolMessage::decode(d.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| "Failed to decode messages".to_string())?;
 
         self.communicator.receive_messages(device_id, messages);
         self.last_update = get_timestamp();

--- a/src/tasks/group.rs
+++ b/src/tasks/group.rs
@@ -9,7 +9,7 @@ use crate::protocols::Protocol;
 use crate::tasks::{Task, TaskResult, TaskStatus};
 use crate::{get_timestamp, utils};
 use log::{info, warn};
-use meesign_crypto::proto::{Message as _, ProtocolMessage};
+use meesign_crypto::proto::{Message as _, ClientMessage};
 use prost::Message as _;
 use std::io::Read;
 use std::process::{Command, Stdio};
@@ -205,7 +205,7 @@ impl Task for GroupTask {
         }
 
         let messages = data.iter()
-            .map(|d| ProtocolMessage::decode(d.as_slice()))
+            .map(|d| ClientMessage::decode(d.as_slice()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "Failed to decode messages".to_string())?;
 

--- a/src/tasks/group.rs
+++ b/src/tasks/group.rs
@@ -9,7 +9,7 @@ use crate::protocols::Protocol;
 use crate::tasks::{Task, TaskResult, TaskStatus};
 use crate::{get_timestamp, utils};
 use log::{info, warn};
-use meesign_crypto::proto::{Message as _, ClientMessage};
+use meesign_crypto::proto::{ClientMessage, Message as _};
 use prost::Message as _;
 use std::io::Read;
 use std::process::{Command, Stdio};
@@ -204,7 +204,8 @@ impl Task for GroupTask {
             return Err("Wasn't waiting for a message from this ID.".to_string());
         }
 
-        let messages = data.iter()
+        let messages = data
+            .iter()
             .map(|d| ClientMessage::decode(d.as_slice()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "Failed to decode messages".to_string())?;

--- a/src/tasks/group.rs
+++ b/src/tasks/group.rs
@@ -209,7 +209,6 @@ impl Task for GroupTask {
             .map(|d| {
                 ProtocolMessage::decode(d.as_slice())
                     .map_err(|_| String::from("Expected ProtocolMessage."))
-                    .map(|m| m.message)
             })
             .collect();
         if messages.iter().any(|m| m.is_err()) {

--- a/src/tasks/group.rs
+++ b/src/tasks/group.rs
@@ -204,17 +204,10 @@ impl Task for GroupTask {
             return Err("Wasn't waiting for a message from this ID.".to_string());
         }
 
-        let messages: Vec<_> = data
-            .iter()
-            .map(|d| {
-                ProtocolMessage::decode(d.as_slice())
-                    .map_err(|_| String::from("Expected ProtocolMessage."))
-            })
-            .collect();
-        if messages.iter().any(|m| m.is_err()) {
-            return Err("Failed to decode messages".to_string());
-        }
-        let messages = messages.into_iter().map(|m| m.unwrap()).collect();
+        let messages = data.iter()
+            .map(|d| ProtocolMessage::decode(d.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| "Failed to decode messages".to_string())?;
 
         self.communicator.receive_messages(device_id, messages);
         self.last_update = get_timestamp();

--- a/src/tasks/sign.rs
+++ b/src/tasks/sign.rs
@@ -8,7 +8,7 @@ use crate::protocols::Protocol;
 use crate::tasks::{Task, TaskResult, TaskStatus};
 use crate::{get_timestamp, utils};
 use log::{info, warn};
-use meesign_crypto::proto::{Message as _, ProtocolMessage};
+use meesign_crypto::proto::{Message as _, ClientMessage};
 use prost::Message as _;
 use tonic::codegen::Arc;
 
@@ -119,7 +119,7 @@ impl SignTask {
         }
 
         let messages = data.iter()
-            .map(|d| ProtocolMessage::decode(d.as_slice()))
+            .map(|d| ClientMessage::decode(d.as_slice()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "Failed to decode messages".to_string())?;
 

--- a/src/tasks/sign.rs
+++ b/src/tasks/sign.rs
@@ -123,7 +123,6 @@ impl SignTask {
             .map(|d| {
                 ProtocolMessage::decode(d.as_slice())
                     .map_err(|_| String::from("Expected ProtocolMessage."))
-                    .map(|m| m.message)
             })
             .collect();
         if messages.iter().any(|m| m.is_err()) {

--- a/src/tasks/sign.rs
+++ b/src/tasks/sign.rs
@@ -8,7 +8,7 @@ use crate::protocols::Protocol;
 use crate::tasks::{Task, TaskResult, TaskStatus};
 use crate::{get_timestamp, utils};
 use log::{info, warn};
-use meesign_crypto::proto::{Message as _, ClientMessage};
+use meesign_crypto::proto::{ClientMessage, Message as _};
 use prost::Message as _;
 use tonic::codegen::Arc;
 
@@ -118,7 +118,8 @@ impl SignTask {
             return Err("Wasn't waiting for a message from this ID.".to_string());
         }
 
-        let messages = data.iter()
+        let messages = data
+            .iter()
             .map(|d| ClientMessage::decode(d.as_slice()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "Failed to decode messages".to_string())?;

--- a/src/tasks/sign.rs
+++ b/src/tasks/sign.rs
@@ -118,17 +118,10 @@ impl SignTask {
             return Err("Wasn't waiting for a message from this ID.".to_string());
         }
 
-        let messages: Vec<_> = data
-            .iter()
-            .map(|d| {
-                ProtocolMessage::decode(d.as_slice())
-                    .map_err(|_| String::from("Expected ProtocolMessage."))
-            })
-            .collect();
-        if messages.iter().any(|m| m.is_err()) {
-            return Err("Failed to decode messages".to_string());
-        }
-        let messages = messages.into_iter().map(|m| m.unwrap()).collect();
+        let messages = data.iter()
+            .map(|d| ProtocolMessage::decode(d.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| "Failed to decode messages".to_string())?;
 
         self.communicator.receive_messages(device_id, messages);
         self.last_update = get_timestamp();


### PR DESCRIPTION
Depends on: crocs-muni/meesign-crypto#3
Cargo.toml needs to be updated afterwards.

Replace sorted vectors with hashmaps, split `ProtocolMessage` into `ClientMessage` and `ServerMessage`, distinguish broadcast and unicast messages.