### PR TITLE
Added support for gRPC streaming of large files

### DIFF
--- a/proto/meesign.proto
+++ b/proto/meesign.proto
@@ -5,8 +5,10 @@ service MeeSign {
   rpc GetServerInfo(ServerInfoRequest) returns (ServerInfo);
   rpc Register(RegistrationRequest) returns (RegistrationResponse);
   rpc Sign(SignRequest) returns (Task);
+  rpc SignStream(stream SignRequestChunk) returns (Task); // streaming for large PDFs
   rpc Group(GroupRequest) returns (Task);
   rpc Decrypt(DecryptRequest) returns (Task);
+  rpc DecryptStream(stream DecryptRequestChunk) returns (Task); // streaming for large images
   rpc GetTask(TaskRequest) returns (Task);
   rpc UpdateTask(TaskUpdate) returns (Resp); // auth required
   rpc DecideTask(TaskDecision) returns (Resp); // auth required
@@ -101,11 +103,40 @@ message SignRequest {
   bytes data = 3;
 }
 
+// Streaming messages for large file uploads
+message SignRequestChunk {
+  oneof payload {
+    SignMetadata metadata = 1;  // First chunk contains metadata
+    bytes chunk = 2;             // Subsequent chunks contain data
+  }
+}
+
+message SignMetadata {
+  string name = 1;
+  bytes group_id = 2;
+  uint64 total_size = 3;  // Total size for progress tracking
+}
+
 message DecryptRequest {
   string name = 1;
   bytes group_id = 2;
   bytes data = 3;
   string data_type = 4; // MIME type of the encrypted data
+}
+
+// Streaming messages for large encrypted data
+message DecryptRequestChunk {
+  oneof payload {
+    DecryptMetadata metadata = 1;  // First chunk contains metadata
+    bytes chunk = 2;                // Subsequent chunks contain data
+  }
+}
+
+message DecryptMetadata {
+  string name = 1;
+  bytes group_id = 2;
+  string data_type = 3;  // MIME type of the encrypted data
+  uint64 total_size = 4;  // Total size for progress tracking
 }
 
 message TaskRequest {

--- a/src/tasks/sign.rs
+++ b/src/tasks/sign.rs
@@ -53,6 +53,7 @@ impl SignTask {
             acknowledgements,
         )));
 
+        // Include original data in request so clients can reconstruct context
         let request = (SignRequest {
             group_id: group.identifier().to_vec(),
             name,


### PR DESCRIPTION
We should eventually remove old "Sign" and "Decrypt" endpoints and keep using only the streaming version to stay consistent and to avoid maintaining 2 endpoints that do almost the same thing. Streaming is preferred over the classic gRPC request as it allows us to bypass max gRPC message size limitation, by chunking the request (like image or PDF upload) into smaller parts that don't struggle with gRPC limitations.

First, let's merge this PR while keeping old Sign and Decrypt endpoints. Once its merged, we can create a new PR where we will remove the old endpoints - this is to keep client and server protobuf definition in sync.

Also, since I am not a Rust developer, please take a look at the Rust code in this PR and check if it does not violate any standards etc @MarekMracna. The current version is working but could probably by improved.


**Note:**
_This protobuf definition is compatible with meesign-client in the [grpc-streaming](https://github.com/crocs-muni/meesign-client/tree/grpc-streaming) branch._