### PR TITLE
Pin rust instead of relying on outdated system version

### DIFF
--- a/integration-tests/Dockerfile.test_client
+++ b/integration-tests/Dockerfile.test_client
@@ -6,7 +6,7 @@ RUN apt install --yes \
     sqlite3 \
     poppler-utils \
     protobuf-compiler \
-    cargo
+    clang
 RUN ln -s /usr/lib/x86_64-linux-gnu/libsqlite3.so.0  /usr/lib/x86_64-linux-gnu/libsqlite3.so
 
 RUN groupadd --gid 1234 test-group
@@ -14,6 +14,9 @@ RUN useradd --create-home --uid 1234 --gid test-group test-client
 RUN chown --recursive test-client:test-group /app
 
 USER test-client
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.91.1
+ENV PATH="/home/test-client/.cargo/bin:${PATH}"
 
 ARG MEESIGN_TEST_CLIENT_REPO_OWNER=crocs-muni
 ARG MEESIGN_TEST_CLIENT_REPO_BRANCH=devel
@@ -29,7 +32,6 @@ RUN cd meesign_native/native/meesign-crypto && cargo build --release --target x8
 WORKDIR /app/meesign-client/meesign_core
 RUN dart pub get
 
-# TODO add test user account?
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/:/app/meesign-client/meesign_native/native/meesign-crypto/target/x86_64-unknown-linux-gnu/release/"
 ENV MEESIGN_SERVER_DOMAIN=meesign-server
 ENV MEESIGN_SERVER_PORT=1337


### PR DESCRIPTION
The point of this pinning is to fix [this](https://github.com/crocs-muni/meesign-server/actions/runs/19176310911/job/54822840891) actions failure due to outdated Rust from the debian image.