### PR TITLE
Fix regression where get_task doesn't work for non-voting tasks

### DIFF
--- a/src/interfaces/grpc.rs
+++ b/src/interfaces/grpc.rs
@@ -156,10 +156,7 @@ impl MeeSign for MeeSignService {
         if let Some(device_id) = device_id {
             self.state.activate_device(device_id);
         }
-        let task = self
-            .state
-            .get_formatted_voting_task(&task_id, device_id)
-            .await?;
+        let task = self.state.get_formatted_task(&task_id, device_id).await?;
         Ok(Response::new(task))
     }
 

--- a/src/task_store.rs
+++ b/src/task_store.rs
@@ -171,7 +171,7 @@ impl TaskStore {
                 &task.task_info.name,
                 task.task_info.protocol_type,
                 task.task_info.key_type,
-                &task.request,
+                &task.task_info.request,
                 note,
             )
             .await?;
@@ -193,7 +193,7 @@ impl TaskStore {
                 group.threshold as u32,
                 &task.task_info.name,
                 data,
-                &task.request,
+                &task.task_info.request,
                 task_type,
                 task.task_info.key_type,
                 task.task_info.protocol_type,
@@ -262,6 +262,7 @@ impl TaskStore {
                 key_type: task_model.key_type,
                 participants,
                 attempts: task_model.attempt_count as u32,
+                request: task_model.request.clone(),
             };
             let task = match task_model.task_type {
                 TaskType::Group => self.group_task_from_model(task_info, task_model).await?,
@@ -329,7 +330,6 @@ impl TaskStore {
                     task_info,
                     decisions,
                     accept_threshold,
-                    request: task_model.request,
                     running_task_context,
                 };
                 Task::Voting(task)
@@ -416,7 +416,6 @@ impl TaskStore {
                     task_info,
                     decisions,
                     accept_threshold,
-                    request: task_model.request,
                     running_task_context,
                 };
                 Task::Voting(task)

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -51,7 +51,6 @@ pub struct VotingTask {
     pub task_info: TaskInfo,
     pub decisions: HashMap<Vec<u8>, i8>,
     pub accept_threshold: u32,
-    pub request: Vec<u8>,
     pub running_task_context: RunningTaskContext,
 }
 impl VotingTask {
@@ -204,6 +203,7 @@ pub struct TaskInfo {
     pub key_type: KeyType,
     pub participants: Vec<Participant>,
     pub attempts: u32,
+    pub request: Vec<u8>,
 }
 impl TaskInfo {
     pub fn total_shares(&self) -> u32 {


### PR DESCRIPTION
Typestates introduced a regression into the get_task endpoint, where it doesn't work for non-voting tasks. This PR fixes it and closes #58.