### PR TITLE
Property testing for Tasks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,12 +26,15 @@ This repository contains a gRPC server which coordinates multi-party threshold p
 
 ## Module structure
 - `persistence` contains code related to the server persistence.
+  - `postgres_repository` contains the Postgres implementation of server persistence
 - `state` contains and manages all of the server's state.
 - `interfaces` contains the modules `grpc` and `timer`, which define long-running services
   - `grpc` provides the server's gRPC endpoints, handles client registration and certificates
   - `timer` periodically runs checks over the state
-- `task_store` manages the persistence and caching of tasks
-- `task` contains the logic for task computation
+- `task_store` defines an interface for managing task lifetime
+- `cached_task_store` an implementation of a task store with persistence and caching
+- `tasks` contains the logic for task computation
+  - `proptest` contains code relevant to property testing with tasks
 - `protocol` contains the logic for protocol computation
 - `communicator` defines the communicator
 - `error` contains definitions of error variants
@@ -40,7 +43,7 @@ This repository contains a gRPC server which coordinates multi-party threshold p
 ## Persistence
 Most of the server state is persisted throughout server restarts, but some state is deliberately ephemeral and kept only in the RAM. The ephemeral state is mostly data which changes "rapidly", namely activity timestamps and messages exchanged during protocol computation.
 
-Persistence is handled in the `state` module, with the exception of `task_store`, which is only used within `state`. This is to decouple the logic from bookkeeping.
+Persistence is handled in the `state` module, with the exception of `cached_task_store`, which is only used within `state`. This is to decouple the logic from bookkeeping.
 
 The `persistence` module is supposed to be a "dumb" interface for communicating with the DB. In particular, it shouldn't validate data, perform complex logic, etc...
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,9 +367,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -382,7 +397,7 @@ checksum = "899ca34eb6924d6ec2a77c6f7f5c7339e60fd68235eaf91edd5a15f12958bb06"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -824,7 +839,7 @@ version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -1947,7 +1962,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "libc",
  "redox_syscall 0.5.11",
 ]
@@ -2102,6 +2117,7 @@ dependencies = [
  "meesign-crypto",
  "mockall",
  "openssl",
+ "proptest",
  "prost 0.12.6",
  "rand 0.8.5",
  "serde",
@@ -2342,7 +2358,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2733,6 +2749,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,6 +2907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +2988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rc2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,7 +3020,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3073,7 +3123,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3086,7 +3136,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
@@ -3178,6 +3228,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,7 +3313,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4190,6 +4252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,6 +4379,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -4692,7 +4769,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,4 @@ db-tests = []
 
 [dev-dependencies]
 mockall = "0.14.0"
+proptest = "1.10.0"

--- a/src/persistence/models.rs
+++ b/src/persistence/models.rs
@@ -19,12 +19,14 @@ pub struct NewDevice<'a> {
 }
 
 #[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub struct Participant {
     pub device: Device,
     pub shares: u32,
 }
 
 #[derive(Queryable, Selectable, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(Debug))]
 #[diesel(table_name = device)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Device {

--- a/src/state.rs
+++ b/src/state.rs
@@ -721,4 +721,25 @@ mod tests {
             assert!(task.is_ok());
         }
     }
+
+    proptest_async! {
+        async fn decisions_work_past_threshold(task in valid_nonvoting_task(5, 3)) {
+            let mut repo = MockRepository::new();
+            repo.expect_get_devices().return_once(|| Ok(Vec::new()));
+            let repo = Arc::new(repo);
+            let mut task_store = MockTaskStore::new();
+            let task_id = task.task_info().id;
+            task_store.expect_get_task_mut().return_once(move |_| {
+                // NOTE: Dummy non-voting task
+                Ok(Box::new(task))
+            });
+            let state = StateInner::<MockTaskStore>::restore(repo, task_store)
+                .await
+                .unwrap();
+            // NOTE: The function called by the `decide` endpoint
+            let result = state.decide_task(&task_id, &[], true).await;
+            // NOTE: Expect no error
+            assert!(result.is_ok());
+        }
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -705,13 +705,13 @@ mod tests {
             let mut repo = MockRepository::new();
             repo.expect_get_devices().return_once(|| Ok(Vec::new()));
             let repo = Arc::new(repo);
-            let mut task_store = MockTaskStore::new();
+            let mut task_store = MockTaskStore::<Box<Task>, Box<Task>>::new();
             let task_id = task.task_info().id;
             task_store.expect_get_task().return_once(move |_| {
                 // NOTE: Dummy non-voting task
                 Ok(Box::new(task))
             });
-            let state = StateInner::<MockTaskStore>::restore(repo, task_store)
+            let state = StateInner::restore(repo, task_store)
                 .await
                 .unwrap();
 
@@ -727,13 +727,13 @@ mod tests {
             let mut repo = MockRepository::new();
             repo.expect_get_devices().return_once(|| Ok(Vec::new()));
             let repo = Arc::new(repo);
-            let mut task_store = MockTaskStore::new();
+            let mut task_store = MockTaskStore::<Box<Task>, Box<Task>>::new();
             let task_id = task.task_info().id;
             task_store.expect_get_task_mut().return_once(move |_| {
                 // NOTE: Dummy non-voting task
                 Ok(Box::new(task))
             });
-            let state = StateInner::<MockTaskStore>::restore(repo, task_store)
+            let state = StateInner::restore(repo, task_store)
                 .await
                 .unwrap();
             // NOTE: The function called by the `decide` endpoint

--- a/src/state.rs
+++ b/src/state.rs
@@ -416,9 +416,12 @@ impl<TS: TaskStore + Sync> StateInner<TS> {
     ) -> Result<(), Error> {
         let task_entry = &mut *self.task_store.get_task_mut(task_id).await?;
         let Task::Voting(task) = task_entry else {
-            return Err(Error::GeneralProtocolError(
-                "Cannot decide non-voting task".into(),
-            ));
+            debug!(
+                "Decision from non-voting task_id={} device_id={}",
+                utils::hextrunc(task_id.as_bytes()),
+                utils::hextrunc(device_id)
+            );
+            return Ok(());
         };
         self.set_task_last_update(task_id);
         let decision_update = task.decide(device_id, accept).await?;
@@ -710,5 +713,39 @@ mod tests {
         let task = state.get_formatted_task(&task_id, None).await;
         // NOTE: Expect no error
         assert!(task.is_ok());
+    }
+
+    #[tokio::test]
+    async fn decisions_work_past_threshold() {
+        let mut repo = MockRepository::new();
+        repo.expect_get_devices().return_once(|| Ok(Vec::new()));
+        let repo = Arc::new(repo);
+        let mut task_store = MockTaskStore::new();
+        let task_id = Uuid::new_v4();
+        task_store.expect_get_task_mut().return_once(move |_| {
+            // NOTE: Dummy non-voting task
+            Ok(Box::new(Task::Declined(DeclinedTask {
+                task_info: TaskInfo {
+                    id: task_id,
+                    name: "".to_string(),
+                    task_type: TaskType::SignChallenge,
+                    protocol_type: ProtocolType::Gg18,
+                    key_type: KeyType::SignChallenge,
+                    participants: Vec::new(),
+                    attempts: 0,
+                    request: Vec::new(),
+                },
+                accepts: 0,
+                rejects: 2,
+            })))
+        });
+        let state = StateInner::<MockTaskStore>::restore(repo, task_store)
+            .await
+            .unwrap();
+
+        // NOTE: The function called by the `decide` endpoint
+        let result = state.decide_task(&task_id, &[], true).await;
+        // NOTE: Expect no error
+        assert!(result.is_ok());
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -424,7 +424,7 @@ impl<TS: TaskStore + Sync> StateInner<TS> {
             return Ok(());
         };
         self.set_task_last_update(task_id);
-        let decision_update = task.decide(device_id, accept).await?;
+        let decision_update = task.decide(device_id, accept)?;
         self.repo
             .set_task_decision(task_id, device_id, accept)
             .await?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -680,7 +680,7 @@ mod tests {
     use crate::persistence::MockRepository;
     use crate::task_store::MockTaskStore;
     use crate::tasks::proptest::{
-        task_info_to_valid_voting_task, valid_nonvoting_task, valid_task_info,
+        task_info_to_valid_voting_task, valid_nonvoting_task, valid_task_info, valid_voting_task,
     };
 
     use proptest::prelude::*;
@@ -755,6 +755,30 @@ mod tests {
             assert!(task.decisions.len() + 1 == task.task_info.participants.len());
 
             task
+        }
+    }
+
+    prop_compose! {
+        fn valid_accepted_task(device_limit: usize, shares_limit: u32)(
+            mut task in valid_voting_task(device_limit, shares_limit),
+        ) -> VotingTask {
+            let candidate_ids: Vec<Vec<u8>> = task
+                .task_info
+                .participants
+                .iter()
+                .map(|participant| &participant.device.id)
+                .filter(|id| !task.decisions.contains_key(id.as_slice()))
+                .cloned()
+                .collect();
+
+            for candidate_id in candidate_ids {
+                match task.decide(&candidate_id, true) {
+                    Ok(DecisionUpdate::Accepted) => return task,
+                    Ok(DecisionUpdate::Undecided) => {},
+                    _ => panic!("Unexpected decision update"),
+                }
+            }
+            panic!("Voting task didn't allow task accept");
         }
     }
 
@@ -914,6 +938,82 @@ mod tests {
             let Task::Declined(_) = *task.lock().await else {
                 panic!("Critical voting task didn't change phase after last decision");
             };
+        }
+    }
+
+    proptest_async! {
+        async fn valid_accepted_task_is_valid(task in valid_accepted_task(5, 3)) {
+            let (accepts, _) = VotingTask::accepts_rejects(&task.decisions);
+            assert!(accepts >= task.accept_threshold);
+        }
+    }
+
+    proptest_async! {
+        async fn choose_active_shares_properties(task in valid_accepted_task(5, 3)) {
+            let mut repo = MockRepository::new();
+            repo.expect_get_devices().return_once(|| Ok(Vec::new()));
+            // TODO: Check the active shares
+            repo.expect_set_task_active_shares().return_once(|_, _| Ok(()));
+            let repo = Arc::new(repo);
+            let task_store = MockTaskStore::<Box<Task>, Box<Task>>::new();
+            let state = StateInner::restore(repo, task_store)
+                .await
+                .unwrap();
+
+            // Run the behavior being tested
+            let Ok(active_shares) = state.choose_active_shares(&task).await else {
+                panic!("Choosing active shares failed unexpectedly");
+            };
+
+            for device in active_shares.values() {
+                // NOTE: Each active share must have accepted participation on the task
+                assert!(task.device_accepted(&device.id), "non-accepting voter chosen as active");
+            }
+
+            // NOTE: We recreate the candidate shares as per the documentation
+            // NOTE: Step 1: Gather all candidate shares sorted by their corresponding device id
+            let mut candidate_shares: Vec<_> = task
+                .task_info
+                .participants
+                .iter()
+                .flat_map(|participant| {
+                    std::iter::repeat_n(participant.device.id.clone(), participant.shares as usize)
+                })
+                .collect();
+            candidate_shares.sort_unstable();
+            // NOTE: Step 2: Assign indices [0..n] to the sorted shares: this is implicit by the vector's indexing
+
+            for (idx, device) in &active_shares {
+                // NOTE: The device id at a given protocol index must be consistent
+                assert_eq!(candidate_shares[*idx as usize], device.id);
+            }
+
+            // NOTE: Step 3: For each device, get the range of indices assigned to its shares
+            let mut candidate_share_ranges: HashMap<Vec<u8>, Vec<u32>> = HashMap::new();
+            for (idx, id) in candidate_shares.into_iter().enumerate() {
+                candidate_share_ranges.entry(id).or_default().push(idx as u32);
+            }
+
+            // NOTE: We also compute the index ranges of the active shares
+            let mut active_share_ranges: HashMap<Vec<u8>, Vec<u32>> = HashMap::new();
+            for (idx, device) in &active_shares {
+                active_share_ranges.entry(device.id.clone()).or_default().push(*idx);
+            }
+
+            for (id, active_range) in &mut active_share_ranges {
+                // NOTE: And sort them
+                active_range.sort_unstable();
+
+                // NOTE: We test correctness of Step 4: Choose the active shares such that for each device, they are chosen from the start of its range
+
+                // NOTE: The index range of a device's active shares must be a prefix of the index range of all its shares
+                let candidate_range = &candidate_share_ranges[id];
+                assert_eq!(active_range, &candidate_range[0..active_range.len()], "active shares are not a prefix of candidate shares");
+            }
+
+            // NOTE: Finally, there must be exactly `accept_threshold` active shares
+            let total_active_shares = active_shares.len() as u32;
+            assert_eq!(total_active_shares, task.accept_threshold);
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -679,10 +679,13 @@ mod tests {
     use super::*;
     use crate::persistence::MockRepository;
     use crate::task_store::MockTaskStore;
-    use crate::tasks::proptest::valid_nonvoting_task;
+    use crate::tasks::proptest::{
+        task_info_to_valid_voting_task, valid_nonvoting_task, valid_task_info,
+    };
 
     use proptest::prelude::*;
     use tokio::runtime::Runtime;
+    use tokio::sync::{Mutex, OwnedMutexGuard};
 
     /// A convenience macro to write tests using both proptest and tokio's async
     macro_rules! proptest_async {
@@ -698,6 +701,61 @@ mod tests {
                 }
             }
         };
+    }
+
+    fn valid_voting_task_excluding_signpdf(
+        device_limit: usize,
+        shares_limit: u32,
+    ) -> impl Strategy<Value = VotingTask> {
+        valid_task_info(device_limit, shares_limit)
+            .prop_filter("unwanted task type", |task_info| {
+                task_info.task_type != TaskType::SignPdf
+            })
+            .prop_flat_map(task_info_to_valid_voting_task)
+    }
+
+    prop_compose! {
+        /// Proptest strategy to generate a critical voting task
+        /// Critical here means that the acceptance/rejection of the task
+        /// depends on one last undecided participant.
+        fn critical_voting_task_excluding_sign_pdf(device_limit: usize, shares_limit: u32)(
+            mut task in valid_voting_task_excluding_signpdf(device_limit, shares_limit),
+        ) -> VotingTask {
+            let mut candidates: Vec<Participant> = task
+                .task_info
+                .participants
+                .iter()
+                .filter(|participant| !task.decisions.contains_key(&participant.device.id))
+                .cloned()
+                .collect();
+            candidates.sort_unstable_by_key(|participant| participant.shares);
+            let (mut accepts, mut rejects) = VotingTask::accepts_rejects(&task.decisions);
+            let mut undecided = task.task_info.total_shares() - accepts - rejects;
+            for candidate in candidates {
+                if candidate.shares + accepts < task.accept_threshold {
+                    // Accept as many as possible
+                    let Ok(DecisionUpdate::Undecided) = task.decide(&candidate.device.id, true) else {
+                        panic!("Valid decision failed");
+                    };
+                    accepts += candidate.shares;
+                    undecided -= candidate.shares;
+                } else if accepts + undecided - candidate.shares >= task.accept_threshold {
+                    // Reject as many as possible
+                    let Ok(DecisionUpdate::Undecided) = task.decide(&candidate.device.id, false) else {
+                        panic!("Valid decision failed");
+                    };
+                    rejects += candidate.shares;
+                    undecided -= candidate.shares;
+                }
+            }
+            // A critical voting task needs at least one undecided participant,
+            // because the voting is not complete. There cannot be more than one,
+            // because an accept-critical decision cannot also be a reject-critical
+            // unless it's the last participant.
+            assert!(task.decisions.len() + 1 == task.task_info.participants.len());
+
+            task
+        }
     }
 
     proptest_async! {
@@ -740,6 +798,122 @@ mod tests {
             let result = state.decide_task(&task_id, &[], true).await;
             // NOTE: Expect no error
             assert!(result.is_ok());
+        }
+    }
+
+    proptest_async! {
+        async fn voting_task_transitions_to_running_with_enough_accepts(task in critical_voting_task_excluding_sign_pdf(5, 3)) {
+            // Prepare repo and task store
+            let mut repo = MockRepository::new();
+            repo.expect_get_devices().return_once(|| Ok(Vec::new()));
+            let mut task_store = MockTaskStore::<OwnedMutexGuard<Task>, OwnedMutexGuard<Task>>::new();
+
+            // Extract task id and task type
+            let task_id = task.task_info.id;
+            let task_type = task.task_info.task_type;
+
+            // Extract the id of the last undecided participant
+            let undecided_participant_ids: Vec<_> = task
+                .task_info
+                .participants
+                .iter()
+                .map(|participant| &participant.device.id)
+                .filter(|id| !task.decisions.contains_key(id.as_slice()))
+                .collect();
+            assert!(undecided_participant_ids.len() == 1);
+            let undecided_participant_id = undecided_participant_ids[0].clone();
+
+
+            // Prepare mutable task reference
+            let task = Arc::new(Mutex::new(Task::Voting(task)));
+            let lock = task.clone().lock_owned().await;
+            task_store.expect_get_task_mut().return_once(move |_| {
+                // NOTE: Reference to our `task`
+                Ok(lock)
+            });
+
+            // Expect that a decision will be stored
+            repo.expect_set_task_decision().return_once(|_, _, _| Ok(()));
+            // And the task will prepare to run
+            repo.expect_set_task_active_shares().return_once(|_, _| Ok(()));
+            // Expectations for the first round
+            match task_type {
+                TaskType::Group => {
+                    repo.expect_set_task_group_certificates_sent().return_once(|_, _| Ok(()));
+                },
+                _ => {
+                    repo.expect_set_task_round().return_once(|_, round| Ok(round));
+                }
+            }
+
+            // Create state
+            let state = StateInner::restore(Arc::new(repo), task_store)
+                .await
+                .unwrap();
+
+            // Run the behavior being tested
+            // NOTE: The function called by the `decide` endpoint
+            state
+                .decide_task(&task_id, &undecided_participant_id, true)
+                .await
+                .unwrap();
+
+            let Task::Running(_) = *task.lock().await else {
+                panic!("Critical voting task didn't change phase after last decision");
+            };
+        }
+    }
+
+    proptest_async! {
+        async fn voting_task_transitions_to_declined_with_enough_rejects(task in critical_voting_task_excluding_sign_pdf(5, 3)) {
+            // Prepare repo and task store
+            let mut repo = MockRepository::new();
+            repo.expect_get_devices().return_once(|| Ok(Vec::new()));
+            let mut task_store = MockTaskStore::<OwnedMutexGuard<Task>, OwnedMutexGuard<Task>>::new();
+
+            // Extract task id
+            let task_id = task.task_info.id;
+
+            // Extract the id of the last undecided participant
+            let undecided_participant_ids: Vec<_> = task
+                .task_info
+                .participants
+                .iter()
+                .map(|participant| &participant.device.id)
+                .filter(|id| !task.decisions.contains_key(id.as_slice()))
+                .collect();
+            assert!(undecided_participant_ids.len() == 1);
+            let undecided_participant_id = undecided_participant_ids[0].clone();
+
+
+            // Prepare mutable task reference
+            let task = Arc::new(Mutex::new(Task::Voting(task)));
+            let lock = task.clone().lock_owned().await;
+            task_store.expect_get_task_mut().return_once(move |_| {
+                // NOTE: Reference to our `task`
+                Ok(lock)
+            });
+
+            // Expect that a decision will be stored
+            repo.expect_set_task_decision().return_once(|_, _, _| Ok(()));
+            // And a (failed) result will be set
+            repo.expect_set_task_result().return_once(|_, _| Ok(()));
+
+            // Create state
+            let state = StateInner::restore(Arc::new(repo), task_store)
+                .await
+                .unwrap();
+
+            // Run the behavior being tested
+            // NOTE: The function called by the `decide` endpoint
+            state
+                .decide_task(&task_id, &undecided_participant_id, false)
+                .await
+                .unwrap();
+
+            let Task::Declined(_) = *task.lock().await else {
+                panic!("Critical voting task didn't change phase after last decision");
+            };
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,7 +17,6 @@ use crate::tasks::{
 use crate::{get_timestamp, utils};
 use meesign_crypto::proto::ClientMessage;
 use prost::Message as _;
-use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::sync::mpsc::Sender;
 use tonic::codegen::Arc;
 use tonic::Status;
@@ -489,66 +488,24 @@ impl<TS: TaskStore + Sync> StateInner<TS> {
     /// The clients expect that out of a participant's [0..n] shares,
     /// exactly the first [0..k] will be chosen.
     async fn choose_active_shares(&self, task: &VotingTask) -> Result<HashMap<u32, Device>, Error> {
-        // NOTE: Threshold tasks need to use indices from group establishment, that is,
-        //       the indices assigned to all task participants. Since we don't store
-        //       any such index mapping, we generate it from a sorted list of devices.
-        let mut all_participants = task.task_info.participants.clone();
-        all_participants.sort_by(|a, b| a.device.id.cmp(&b.device.id));
-        let first_share_indices: HashMap<Vec<u8>, u32> = all_participants
-            .into_iter()
-            .scan(0, |idx, p| {
-                let first_share = *idx;
-                *idx += p.shares;
-                Some((p.device.id.clone(), first_share))
-            })
-            .collect();
+        let latest_acceptable_time = get_timestamp() - 5; // TODO: Factor the constant out
 
-        let accepting_participants: Vec<&Participant> = task
-            .task_info
-            .participants
-            .iter()
-            .filter(|p| task.device_accepted(&p.device.id))
-            .collect();
-        let latest_acceptable_time = get_timestamp() - 5;
-        let connected_participants: Vec<&Participant> = accepting_participants
-            .iter()
-            .filter(|p| {
-                let last_active_time = self.get_device_last_activation(&p.device.id);
-                last_active_time > latest_acceptable_time
-            })
-            .copied()
-            .collect();
+        let active_shares = task.choose_active_shares(|participant| {
+            let last_active_time = self.get_device_last_activation(&participant.device.id);
+            last_active_time > latest_acceptable_time
+        });
 
-        let total_connected_shares: u32 = connected_participants.iter().map(|p| p.shares).sum();
-        let candidates = if total_connected_shares >= task.accept_threshold {
-            connected_participants
-        } else {
-            accepting_participants
-        };
-
-        let chosen_devices = candidates
-            .into_iter()
-            .flat_map(|p| std::iter::repeat_n(&p.device, p.shares as usize))
-            .choose_multiple(&mut thread_rng(), task.accept_threshold as usize);
-
-        let mut active_shares = HashMap::new();
-        for device in &chosen_devices {
-            *active_shares.entry(device.id.clone()).or_default() += 1;
+        // NOTE: We need to persist the number of active shares per device
+        let mut active_share_counts = HashMap::new();
+        for device in active_shares.values() {
+            *active_share_counts.entry(device.id.clone()).or_default() += 1;
         }
+
         self.repo
-            .set_task_active_shares(&task.task_info.id, &active_shares)
+            .set_task_active_shares(&task.task_info.id, &active_share_counts)
             .await?;
 
-        let active_devices = chosen_devices
-            .into_iter()
-            .scan(first_share_indices, |share_indices, device| {
-                let share_index = share_indices[&device.id];
-                *share_indices.get_mut(&device.id).unwrap() += 1;
-                Some((share_index, device.clone()))
-            })
-            .collect();
-
-        Ok(active_devices)
+        Ok(active_shares)
     }
 
     pub async fn acknowledge_task(&self, task_id: &Uuid, device: &[u8]) -> Result<(), Error> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -679,73 +679,46 @@ mod tests {
     use super::*;
     use crate::persistence::MockRepository;
     use crate::task_store::MockTaskStore;
-    use crate::tasks::DeclinedTask;
+    use crate::tasks::proptest::valid_nonvoting_task;
 
-    #[tokio::test]
-    async fn get_task_works_with_non_voting_task() {
-        let mut repo = MockRepository::new();
-        repo.expect_get_devices().return_once(|| Ok(Vec::new()));
-        let repo = Arc::new(repo);
-        let mut task_store = MockTaskStore::new();
-        let task_id = Uuid::new_v4();
-        task_store.expect_get_task().return_once(move |_| {
-            // NOTE: Dummy non-voting task
-            Ok(Box::new(Task::Declined(DeclinedTask {
-                task_info: TaskInfo {
-                    id: task_id,
-                    name: "".to_string(),
-                    task_type: TaskType::SignChallenge,
-                    protocol_type: ProtocolType::Gg18,
-                    key_type: KeyType::SignChallenge,
-                    participants: Vec::new(),
-                    attempts: 0,
-                    request: Vec::new(),
-                },
-                accepts: 0,
-                rejects: 2,
-            })))
-        });
-        let state = StateInner::<MockTaskStore>::restore(repo, task_store)
-            .await
-            .unwrap();
+    use proptest::prelude::*;
+    use tokio::runtime::Runtime;
 
-        // NOTE: The function called by the `get_task` endpoint
-        let task = state.get_formatted_task(&task_id, None).await;
-        // NOTE: Expect no error
-        assert!(task.is_ok());
+    /// A convenience macro to write tests using both proptest and tokio's async
+    macro_rules! proptest_async {
+        (
+            $(#[$meta:meta])*
+            async fn $name:ident ( $($args:tt)* ) $(-> $ret:ty)? $body:block
+        ) => {
+            proptest! {
+                #[test]
+                $(#[$meta])*
+                fn $name($($args)*) $(-> $ret)? {
+                    Runtime::new().unwrap().block_on(async $body)
+                }
+            }
+        };
     }
 
-    #[tokio::test]
-    async fn decisions_work_past_threshold() {
-        let mut repo = MockRepository::new();
-        repo.expect_get_devices().return_once(|| Ok(Vec::new()));
-        let repo = Arc::new(repo);
-        let mut task_store = MockTaskStore::new();
-        let task_id = Uuid::new_v4();
-        task_store.expect_get_task_mut().return_once(move |_| {
-            // NOTE: Dummy non-voting task
-            Ok(Box::new(Task::Declined(DeclinedTask {
-                task_info: TaskInfo {
-                    id: task_id,
-                    name: "".to_string(),
-                    task_type: TaskType::SignChallenge,
-                    protocol_type: ProtocolType::Gg18,
-                    key_type: KeyType::SignChallenge,
-                    participants: Vec::new(),
-                    attempts: 0,
-                    request: Vec::new(),
-                },
-                accepts: 0,
-                rejects: 2,
-            })))
-        });
-        let state = StateInner::<MockTaskStore>::restore(repo, task_store)
-            .await
-            .unwrap();
+    proptest_async! {
+        async fn get_task_works_with_non_voting_task(task in valid_nonvoting_task(5, 3)) {
+            let mut repo = MockRepository::new();
+            repo.expect_get_devices().return_once(|| Ok(Vec::new()));
+            let repo = Arc::new(repo);
+            let mut task_store = MockTaskStore::new();
+            let task_id = task.task_info().id;
+            task_store.expect_get_task().return_once(move |_| {
+                // NOTE: Dummy non-voting task
+                Ok(Box::new(task))
+            });
+            let state = StateInner::<MockTaskStore>::restore(repo, task_store)
+                .await
+                .unwrap();
 
-        // NOTE: The function called by the `decide` endpoint
-        let result = state.decide_task(&task_id, &[], true).await;
-        // NOTE: Expect no error
-        assert!(result.is_ok());
+            // NOTE: The function called by the `get_task` endpoint
+            let task = state.get_formatted_task(&task_id, None).await;
+            // NOTE: Expect no error
+            assert!(task.is_ok());
+        }
     }
 }

--- a/src/task_store.rs
+++ b/src/task_store.rs
@@ -1,7 +1,9 @@
 use crate::error::Error;
 use crate::tasks::{Task, VotingTask};
 use async_trait::async_trait;
+use std::future::Future;
 use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
 use uuid::Uuid;
 
 #[async_trait]
@@ -29,7 +31,11 @@ use mockall::mock;
 
 #[cfg(test)]
 mock! {
-    pub TaskStore {
+    pub TaskStore<Ref, RefMut>
+    where
+        Ref: Deref<Target = Task> + Send,
+        RefMut: DerefMut<Target = Task> + Send,
+    {
         pub fn persist_task(&self, task: VotingTask) ->
             Result<Option<Task>, Error>;
         pub fn get_task(&self, task_id: &Uuid) ->
@@ -41,18 +47,48 @@ mock! {
 
 // TODO: Mock the async behavior as well.
 #[cfg(test)]
-#[async_trait]
-impl TaskStore for MockTaskStore {
-    type TaskRef = Box<Task>;
-    type TaskRefMut = Box<Task>;
+// #[async_trait]
+impl<Ref, RefMut> TaskStore for MockTaskStore<Ref, RefMut>
+where
+    Ref: Deref<Target = Task> + Send,
+    RefMut: DerefMut<Target = Task> + Send,
+{
+    type TaskRef = Ref;
+    type TaskRefMut = RefMut;
 
-    async fn persist_task(&self, task: VotingTask) -> Result<Option<Task>, Error> {
-        self.persist_task(task)
+    fn persist_task<'life0, 'async_trait>(
+        &'life0 self,
+        task: VotingTask,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Task>, Error>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        let res = self.persist_task(task);
+        Box::pin(async move { res })
     }
-    async fn get_task(&self, task_id: &Uuid) -> Result<Self::TaskRef, Error> {
-        self.get_task(task_id)
+    fn get_task<'life0, 'life1, 'async_trait>(
+        &'life0 self,
+        task_id: &'life1 Uuid,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::TaskRef, Error>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        let res = self.get_task(task_id);
+        Box::pin(async move { res })
     }
-    async fn get_task_mut(&self, task_id: &Uuid) -> Result<Self::TaskRefMut, Error> {
-        self.get_task_mut(task_id)
+    fn get_task_mut<'life0, 'life1, 'async_trait>(
+        &'life0 self,
+        task_id: &'life1 Uuid,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::TaskRefMut, Error>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        let res = self.get_task_mut(task_id);
+        Box::pin(async move { res })
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod sign_pdf;
 pub(crate) mod proptest;
 
 use meesign_crypto::proto::ClientMessage;
+use rand::{prelude::IteratorRandom, thread_rng};
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
@@ -108,6 +109,65 @@ impl VotingTask {
     }
     pub fn device_accepted(&self, device_id: &[u8]) -> bool {
         self.decisions.get(device_id) > Some(&0)
+    }
+
+    pub fn choose_active_shares(
+        &self,
+        is_preferred: impl Fn(&Participant) -> bool,
+    ) -> HashMap<u32, Device> {
+        // NOTE: Threshold tasks need to use indices from group establishment, that is,
+        //       the indices assigned to all task participants. Since we don't store
+        //       any such index mapping, we generate it from a sorted list of devices.
+        let mut all_participants = self.task_info.participants.clone();
+        all_participants.sort_by(|a, b| a.device.id.cmp(&b.device.id));
+        let first_share_indices: HashMap<Vec<u8>, u32> = all_participants
+            .into_iter()
+            .scan(0, |idx, p| {
+                let first_share = *idx;
+                *idx += p.shares;
+                Some((p.device.id.clone(), first_share))
+            })
+            .collect();
+
+        let accepting_participants: Vec<&Participant> = self
+            .task_info
+            .participants
+            .iter()
+            .filter(|participant| self.device_accepted(&participant.device.id))
+            .collect();
+
+        let preferred_participants: Vec<&Participant> = accepting_participants
+            .iter()
+            .copied()
+            .filter(|&participant| is_preferred(participant))
+            .collect();
+
+        let total_preferred_shares: u32 = preferred_participants
+            .iter()
+            .map(|participant| participant.shares)
+            .sum();
+
+        let candidate_participants = if total_preferred_shares >= self.accept_threshold {
+            preferred_participants
+        } else {
+            accepting_participants
+        };
+
+        let chosen_shares = candidate_participants
+            .into_iter()
+            .flat_map(|p| std::iter::repeat_n(&p.device, p.shares as usize))
+            .choose_multiple(&mut thread_rng(), self.accept_threshold as usize);
+
+        let active_shares = chosen_shares
+            .into_iter()
+            .scan(first_share_indices, |share_indices, device| {
+                let share_index = share_indices[&device.id];
+                *share_indices.get_mut(&device.id).unwrap() += 1;
+                Some((share_index, device.clone()))
+            })
+            .collect();
+
+        active_shares
     }
 }
 #[cfg_attr(test, derive(Debug))]

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -207,7 +207,7 @@ pub struct FailedTask {
 #[must_use]
 pub enum Task {
     Voting(VotingTask),
-    Running(Box<dyn RunningTask + Send + Sync>),
+    Running(Box<dyn RunningTask>),
     Declined(DeclinedTask),
     Finished(FinishedTask),
     Failed(FailedTask),
@@ -372,5 +372,12 @@ impl std::fmt::Debug for Task {
             Task::Failed(t) => write!(f, "Failed({:?})", t),
             Task::Running(_) => write!(f, "Running(..)"),
         }
+    }
+}
+
+#[cfg(test)]
+impl std::fmt::Debug for dyn RunningTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RunningTask(..)")
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -3,6 +3,9 @@ pub(crate) mod group;
 pub(crate) mod sign;
 pub(crate) mod sign_pdf;
 
+#[cfg(test)]
+pub(crate) mod proptest;
+
 use meesign_crypto::proto::ClientMessage;
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
@@ -28,6 +31,7 @@ pub enum DecisionUpdate {
     Declined(DeclinedTask),
 }
 
+#[cfg_attr(test, derive(Clone, Debug))]
 pub enum TaskResult {
     GroupEstablished(Group),
     Signed(Vec<u8>),
@@ -46,6 +50,7 @@ impl TaskResult {
     }
 }
 
+#[cfg_attr(test, derive(Debug))]
 #[must_use]
 pub struct VotingTask {
     pub task_info: TaskInfo,
@@ -78,6 +83,7 @@ impl VotingTask {
         let decision_update = if accepts >= self.accept_threshold {
             DecisionUpdate::Accepted
         } else if rejects >= self.reject_threshold() {
+            // TODO: Check using potential acceptors instead, allowing for earlier rejection
             DecisionUpdate::Declined(DeclinedTask {
                 task_info: self.task_info.clone(),
                 accepts,
@@ -108,12 +114,14 @@ impl VotingTask {
         self.decisions.get(device_id) > Some(&0)
     }
 }
+#[cfg_attr(test, derive(Debug))]
 #[must_use]
 pub struct DeclinedTask {
     pub task_info: TaskInfo,
     pub accepts: u32,
     pub rejects: u32,
 }
+#[cfg_attr(test, derive(Debug))]
 #[must_use]
 pub struct FinishedTask {
     pub task_info: TaskInfo,
@@ -133,11 +141,13 @@ impl FinishedTask {
         self.acknowledgements.insert(device_id.to_vec());
     }
 }
+#[cfg_attr(test, derive(Debug))]
 #[must_use]
 pub struct FailedTask {
     pub task_info: TaskInfo,
     pub reason: String,
 }
+
 #[must_use]
 pub enum Task {
     Voting(VotingTask),
@@ -195,6 +205,7 @@ impl Task {
 }
 
 #[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub struct TaskInfo {
     pub id: Uuid,
     pub name: String,
@@ -234,6 +245,7 @@ pub trait RunningTask: Send + Sync {
 }
 
 #[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub enum RunningTaskContext {
     Group {
         threshold: u32,
@@ -291,5 +303,18 @@ impl RunningTaskContext {
             )),
         };
         Ok(task)
+    }
+}
+
+#[cfg(test)]
+impl std::fmt::Debug for Task {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Task::Voting(t) => write!(f, "Voting({:?})", t),
+            Task::Declined(t) => write!(f, "Declined({:?})", t),
+            Task::Finished(t) => write!(f, "Finished({:?})", t),
+            Task::Failed(t) => write!(f, "Failed({:?})", t),
+            Task::Running(_) => write!(f, "Running(..)"),
+        }
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -59,11 +59,7 @@ pub struct VotingTask {
     pub running_task_context: RunningTaskContext,
 }
 impl VotingTask {
-    pub async fn decide(
-        &mut self,
-        device_id: &[u8],
-        accept: bool,
-    ) -> Result<DecisionUpdate, Error> {
+    pub fn decide(&mut self, device_id: &[u8], accept: bool) -> Result<DecisionUpdate, Error> {
         let shares = self
             .task_info
             .participants

--- a/src/tasks/proptest.rs
+++ b/src/tasks/proptest.rs
@@ -162,16 +162,13 @@ fn voting_task_decisions(
     task_info: &TaskInfo,
     accept_threshold: u32,
 ) -> impl Strategy<Value = HashMap<Vec<u8>, i8>> {
-    // If the accumulated shares of accepting participants exceed the accept threshold,
-    // the task is accepted and thus not voting. We need to limit the accepting participants.
-    // To avoid `prop_filter`, we randomly shuffle the participants, and keep only
-    // the longest prefix whose total shares cannot exceed the threshold,
-    // even if all of them accept.
+    // We shuffle the participants once to avoid choosing random subsets later
     let shuffled_participants = Just(task_info.participants.clone()).prop_shuffle();
     (shuffled_participants).prop_flat_map(move |shuffled_participants| {
-        // A set of participants with fewer total shares than the accept threshold
-        let potential_voters: Vec<Participant> = shuffled_participants
-            .into_iter()
+        // The longest prefix of voters who can accept without change the task phase
+        let potentially_accepting_voters: Vec<Participant> = shuffled_participants
+            .iter()
+            .cloned()
             .scan(0, |acc_shares, participant| {
                 *acc_shares += participant.shares;
                 if *acc_shares < accept_threshold {
@@ -181,29 +178,58 @@ fn voting_task_decisions(
                 }
             })
             .collect();
+        // We pick some of them to actually accept
+        (0..=potentially_accepting_voters.len()).prop_flat_map(move |n_accepting_voters| {
+            let mut shuffled_participants = shuffled_participants.clone();
+            // These voters definitely accept
+            let accepting_voters = &shuffled_participants[0..n_accepting_voters];
+            let total_accepting_shares: u32 = accepting_voters
+                .iter()
+                .map(|participant| participant.shares)
+                .sum();
+            let accepting_decisions: HashMap<Vec<u8>, i8> = accepting_voters
+                .iter()
+                .map(|participant| (participant.device.id.clone(), participant.shares as i8))
+                .collect();
 
-        // Generate a subset of the potential voters
-        let voter_indices = range_subset::range_subset(
-            0..potential_voters.len(),  // NOTE: From indices 0..n_potential_voters
-            0..=potential_voters.len(), //       we select 0 up to n_potential_voters
-        );
-        // Generate arbitrary decisions for the voters
-        let votes =
-            prop::collection::vec(prop_oneof![Just(true), Just(false)], potential_voters.len());
-        (voter_indices, votes).prop_map(move |(voter_indices, votes)| {
-            voter_indices
-                .into_iter()
-                .map(|voter_idx| {
-                    let participant = &potential_voters[voter_idx];
-                    let accepted = votes[voter_idx];
-                    let vote = if accepted {
-                        participant.shares as i8
+            // The rest cannot accept
+            let mut non_accepting_voters = shuffled_participants.split_off(n_accepting_voters);
+
+            // These voters must stay undecided to ensure that the task can still be accepted,
+            // i.e. it is not declined
+            let definitely_undecided_voters: Vec<Participant> = non_accepting_voters
+                .iter()
+                .cloned()
+                .scan(0, |acc_shares, participant| {
+                    let participant_shares = participant.shares;
+                    let res = if *acc_shares + total_accepting_shares < accept_threshold {
+                        Some(participant)
                     } else {
-                        -(participant.shares as i8)
+                        None
                     };
-                    (participant.device.id.clone(), vote)
+                    *acc_shares += participant_shares;
+                    res
                 })
-                .collect()
+                .collect();
+
+            // The rest may decide to either hold their vote or reject
+            let non_accepting_voters =
+                non_accepting_voters.split_off(definitely_undecided_voters.len());
+
+            // We pick some of them to reject
+            (0..=non_accepting_voters.len()).prop_map({
+                let non_accepting_voters = non_accepting_voters;
+                let accepting_decisions = accepting_decisions;
+                move |n_rejecting_voters| {
+                    let mut decisions = accepting_decisions.clone();
+                    let rejecting_voters = &non_accepting_voters[0..n_rejecting_voters];
+                    let rejecting_decisions = rejecting_voters.into_iter().map(|participant| {
+                        (participant.device.id.clone(), -(participant.shares as i8))
+                    });
+                    decisions.extend(rejecting_decisions);
+                    decisions
+                }
+            })
         })
     })
 }
@@ -242,20 +268,14 @@ pub fn valid_voting_task(
     })
 }
 
-fn declined_task_decisions(
+fn declined_task_accepts_rejects(
     task_info: &TaskInfo,
     accept_threshold: u32,
-) -> impl Strategy<Value = HashMap<Vec<u8>, i8>> {
-    // The task is declined if it becomes impossible to accept the task even if all undecided
-    // participants accepted. We calculate the minimum amount of rejects and let the others
-    // decide randomly.
-    // To avoid `prop_filter`, we randomly shuffle the participants, and find the longest
-    // prefix whose total shares cannot exceed the threshold, even if all of them accept.
-    // The rest must reject, but this prefix can decide arbitrarily.
+) -> impl Strategy<Value = (u32, u32)> {
     let shuffled_participants = Just(task_info.participants.clone()).prop_shuffle();
     (shuffled_participants).prop_flat_map(move |shuffled_participants| {
-        // A set of participants with fewer total shares than the accept threshold
-        let arbitrary_voters: Vec<Participant> = shuffled_participants
+        // The longest prefix with total shares fewer than the accept threshold
+        let potentially_non_rejecting_voters: Vec<Participant> = shuffled_participants
             .iter()
             .cloned()
             .scan(0, |acc_shares, participant| {
@@ -268,39 +288,35 @@ fn declined_task_decisions(
             })
             .collect();
 
-        // The participants which need to reject for the task to be declined
-        let rejecting_voters = &shuffled_participants[arbitrary_voters.len()..];
+        // Pick some of them to actually not reject
+        (0..=potentially_non_rejecting_voters.len()).prop_flat_map(move |n_non_rejecting_voters| {
+            let mut shuffled_participants = shuffled_participants.clone();
 
-        let rejecting_decisions: HashMap<_, _> = rejecting_voters
-            .into_iter()
-            .map(|participant| (participant.device.id.clone(), -(participant.shares as i8)))
-            .collect();
+            // The participants which need to reject for the task to be declined
+            let rejecting_voters = &shuffled_participants[n_non_rejecting_voters..];
+            let rejects = rejecting_voters
+                .iter()
+                .map(|participant| participant.shares)
+                .sum();
 
-        // Generate a subset of the arbitrary voters, representing those who actually vote
-        let voter_indices = range_subset::range_subset(
-            0..arbitrary_voters.len(),  // NOTE: From indices 0..n_arbitrary_voters
-            0..=arbitrary_voters.len(), //       we select 0 up to n_arbitrary_voters
-        );
-        // Generate arbitrary decisions for the voters
-        let votes =
-            prop::collection::vec(prop_oneof![Just(true), Just(false)], arbitrary_voters.len());
-        (voter_indices, votes).prop_map({
-            let rejecting_decisions = rejecting_decisions.clone();
-            move |(voter_indices, votes)| {
-                let mut rejecting_decisions = rejecting_decisions.clone();
-                let arbitrary_votes = voter_indices.into_iter().map(|voter_idx| {
-                    let participant = &arbitrary_voters[voter_idx];
-                    let accepted = votes[voter_idx];
-                    let vote = if accepted {
-                        participant.shares as i8
-                    } else {
-                        -(participant.shares as i8)
-                    };
-                    (participant.device.id.clone(), vote)
-                });
-                rejecting_decisions.extend(arbitrary_votes);
-                rejecting_decisions
-            }
+            shuffled_participants.truncate(n_non_rejecting_voters);
+            let non_rejecting_voters = shuffled_participants;
+
+            // NOTE: This must hold because the total shares of non-rejecting voters are strictly
+            //       fewer than the accept threshold
+            assert!(rejects > 0);
+
+            // Pick some of the non-rejecting voters to actually accept
+            (0..=n_non_rejecting_voters).prop_map(move |n_accepting_voters| {
+                let non_rejecting_voters = non_rejecting_voters.clone();
+                let accepting_voters = &non_rejecting_voters[0..n_accepting_voters];
+                let accepts = accepting_voters
+                    .iter()
+                    .map(|participant| participant.shares)
+                    .sum();
+
+                (accepts, rejects)
+            })
         })
     })
 }
@@ -313,16 +329,12 @@ pub fn valid_declined_task(
     valid_task_info(device_limit, shares_limit).prop_flat_map(|task_info| {
         let total_shares = task_info.total_shares();
         (1..=total_shares).prop_flat_map(move |accept_threshold| {
-            declined_task_decisions(&task_info, accept_threshold).prop_map({
+            declined_task_accepts_rejects(&task_info, accept_threshold).prop_map({
                 let task_info = task_info.clone();
-                move |decisions| {
-                    let accepts = decisions.values().filter(|&vote| *vote > 0).count() as u32;
-                    let rejects = decisions.values().filter(|&vote| *vote < 0).count() as u32;
-                    DeclinedTask {
-                        task_info: task_info.clone(),
-                        accepts,
-                        rejects,
-                    }
+                move |(accepts, rejects)| DeclinedTask {
+                    task_info: task_info.clone(),
+                    accepts,
+                    rejects,
                 }
             })
         })

--- a/src/tasks/proptest.rs
+++ b/src/tasks/proptest.rs
@@ -234,38 +234,41 @@ fn voting_task_decisions(
     })
 }
 
+pub fn task_info_to_valid_voting_task(task_info: TaskInfo) -> impl Strategy<Value = VotingTask> {
+    let total_shares = task_info.total_shares();
+    let min_accept_threshold = match task_info.task_type {
+        TaskType::Group => total_shares,
+        _ => 1,
+    };
+    // Just like when creating a task in the client, we first specify
+    // the accept threshold, which is implicitly `total_shares` for group tasks
+    (min_accept_threshold..=total_shares).prop_flat_map({
+        let task_info = task_info.clone();
+        move |accept_threshold| {
+            (
+                voting_task_decisions(&task_info, accept_threshold),
+                valid_running_task_context(&task_info, accept_threshold),
+            )
+                .prop_map({
+                    let task_info = task_info.clone();
+                    move |(decisions, running_task_context)| VotingTask {
+                        task_info: task_info.clone(),
+                        decisions,
+                        accept_threshold,
+                        running_task_context,
+                    }
+                })
+        }
+    })
+}
+
 /// Proptest strategy to generate a valid voting task
 pub fn valid_voting_task(
     device_limit: usize,
     shares_limit: u32,
 ) -> impl Strategy<Value = VotingTask> {
-    valid_task_info(device_limit, shares_limit).prop_flat_map(move |task_info| {
-        let total_shares = task_info.total_shares();
-        let min_accept_threshold = match task_info.task_type {
-            TaskType::Group => total_shares,
-            _ => 1,
-        };
-        // Just like when creating a task in the client, we first specify
-        // the accept threshold, which is implicitly `total_shares` for group tasks
-        (min_accept_threshold..=total_shares).prop_flat_map({
-            let task_info = task_info.clone();
-            move |accept_threshold| {
-                (
-                    voting_task_decisions(&task_info, accept_threshold),
-                    valid_running_task_context(&task_info, accept_threshold),
-                )
-                    .prop_map({
-                        let task_info = task_info.clone();
-                        move |(decisions, running_task_context)| VotingTask {
-                            task_info: task_info.clone(),
-                            decisions,
-                            accept_threshold,
-                            running_task_context,
-                        }
-                    })
-            }
-        })
-    })
+    valid_task_info(device_limit, shares_limit)
+        .prop_flat_map(|task_info| task_info_to_valid_voting_task(task_info))
 }
 
 fn declined_task_accepts_rejects(
@@ -408,10 +411,31 @@ pub fn valid_nonvoting_task(device_limit: usize, shares_limit: u32) -> impl Stra
     ]
 }
 
+/// Proptest strategy to generate a valid voting task with a specified task type
+pub fn valid_voting_task_of_type(
+    device_limit: usize,
+    shares_limit: u32,
+    task_type: TaskType,
+) -> impl Strategy<Value = VotingTask> {
+    valid_task_info(device_limit, shares_limit)
+        .prop_filter("unwanted task type", move |task_info| {
+            task_info.task_type == task_type
+        })
+        .prop_flat_map(task_info_to_valid_voting_task)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proto;
     use std::collections::HashSet;
+
+    proptest! {
+        #[test]
+        fn task_info_is_valid(task_info in valid_task_info(5, 3)) {
+            assert!(task_info.total_shares() >= 2);
+        }
+    }
 
     proptest! {
         #[test]
@@ -425,6 +449,7 @@ mod tests {
                 .map(|participant| participant.shares)
                 .sum();
 
+            assert!(task.accept_threshold >= 2);
             assert!(accept_shares < task.accept_threshold);
             assert!(accept_shares + undecided_shares >= task.accept_threshold);
             assert!(accept_shares + reject_shares + undecided_shares == task.task_info.total_shares());
@@ -449,6 +474,30 @@ mod tests {
             assert!(task.accepts + task.rejects <= task.task_info.total_shares());
 
             // TODO: Check that accepts and rejects are sums of shares of disjoint subsets?
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn group_voting_task_is_valid(task in valid_voting_task_of_type(5, 3, TaskType::Group)) {
+            let protocol_type = proto::ProtocolType::from(task.task_info.protocol_type);
+            let RunningTaskContext::Group{threshold, ..} = task.running_task_context else {
+                panic!("Invalid running task context for a group voting task");
+            };
+            assert!(protocol_type.check_threshold(threshold, task.task_info.total_shares()));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn sign_pdf_voting_task_is_valid(task in valid_voting_task_of_type(5, 3, TaskType::SignPdf)) {
+            let RunningTaskContext::SignPdf{data, ..} = task.running_task_context else {
+                panic!("Invalid running task context for a sign PDF voting task");
+            };
+            let task_name = task.task_info.name;
+            assert!(data.len() <= 8 * 1024 * 1024);
+            assert!(task_name.len() <= 256, "task name has len() = {}", task_name.len());
+            assert!(task_name.chars().all(|x| !x.is_control()));
         }
     }
 }

--- a/src/tasks/proptest.rs
+++ b/src/tasks/proptest.rs
@@ -395,3 +395,48 @@ pub fn valid_nonvoting_task(device_limit: usize, shares_limit: u32) -> impl Stra
         // TODO: Add running task
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    proptest! {
+        #[test]
+        fn voting_task_is_valid(task in valid_voting_task(5, 3)) {
+            let (accept_shares, reject_shares) = VotingTask::accepts_rejects(&task.decisions);
+            let undecided_shares: u32 = task
+                .task_info
+                .participants
+                .iter()
+                .filter(|participant| !task.decisions.contains_key(&participant.device.id))
+                .map(|participant| participant.shares)
+                .sum();
+
+            assert!(accept_shares < task.accept_threshold);
+            assert!(accept_shares + undecided_shares >= task.accept_threshold);
+            assert!(accept_shares + reject_shares + undecided_shares == task.task_info.total_shares());
+
+            let participant_id_set: HashSet<_> = task
+                .task_info
+                .participants
+                .into_iter()
+                .map(|participant| participant.device.id)
+                .collect();
+
+            for (participant_id, _) in &task.decisions {
+                assert!(participant_id_set.contains(participant_id));
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn declined_task_is_valid(task in valid_declined_task(5, 3)) {
+            assert!(task.rejects >= 1);
+            assert!(task.accepts + task.rejects <= task.task_info.total_shares());
+
+            // TODO: Check that accepts and rejects are sums of shares of disjoint subsets?
+        }
+    }
+}

--- a/src/tasks/proptest.rs
+++ b/src/tasks/proptest.rs
@@ -1,0 +1,397 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use proptest::range_subset;
+use uuid::Uuid;
+
+use std::collections::HashMap;
+
+use super::{
+    DeclinedTask, FailedTask, FinishedTask, RunningTaskContext, Task, TaskInfo, TaskResult,
+    VotingTask,
+};
+use crate::persistence::{Device, DeviceKind, Group, KeyType, Participant, ProtocolType, TaskType};
+
+prop_compose! {
+    /// Proptest strategy to generate a valid device id
+    pub fn valid_device_id()(bytes in any::<[u8; 32]>()) -> Vec<u8> {
+        Vec::from(bytes)
+    }
+}
+
+prop_compose! {
+    /// Proptest strategy to generate a valid set of participants
+    pub fn valid_participants(device_limit: usize, shares_limit: u32)(n_devices in 2..device_limit)(
+        device_ids in prop::collection::hash_set(valid_device_id(), n_devices),
+        device_shares in prop::collection::vec(1..shares_limit, n_devices),
+    ) -> Vec<Participant> {
+        device_ids
+            .into_iter()
+            .zip(device_shares.into_iter())
+            .map(|(id, shares)| {
+                Participant {
+                    device: Device {
+                        id,
+                        name: "".to_string(),    // TODO: Randomize device name
+                        kind: DeviceKind::User,  // TODO: Randomize device kind
+                        certificate: Vec::new(), // TODO: Randomize certificate
+                    },
+                    shares,
+                }
+            })
+            .collect()
+    }
+}
+
+/// Proptest strategy to generate a valid "task triple":
+/// a supported combination of task type, protocol type and key type
+pub fn valid_task_triple() -> impl Strategy<Value = (TaskType, ProtocolType, KeyType)> {
+    prop_oneof![
+        Just((TaskType::Group, ProtocolType::Gg18, KeyType::SignPdf)),
+        Just((TaskType::SignPdf, ProtocolType::Gg18, KeyType::SignPdf)),
+        Just((TaskType::Group, ProtocolType::Gg18, KeyType::SignChallenge)),
+        Just((
+            TaskType::SignChallenge,
+            ProtocolType::Gg18,
+            KeyType::SignChallenge
+        )),
+        Just((TaskType::Group, ProtocolType::Frost, KeyType::SignChallenge)),
+        Just((
+            TaskType::SignChallenge,
+            ProtocolType::Frost,
+            KeyType::SignChallenge
+        )),
+        Just((
+            TaskType::Group,
+            ProtocolType::Musig2,
+            KeyType::SignChallenge
+        )),
+        Just((
+            TaskType::SignChallenge,
+            ProtocolType::Musig2,
+            KeyType::SignChallenge
+        )),
+        Just((TaskType::Group, ProtocolType::ElGamal, KeyType::Decrypt)),
+        Just((TaskType::Decrypt, ProtocolType::ElGamal, KeyType::Decrypt)),
+    ]
+}
+
+prop_compose! {
+    /// Proptest strategy to generate a valid task info
+    pub fn valid_task_info(device_limit: usize, shares_limit: u32)(
+        name in ".*",
+        (task_type, protocol_type, key_type) in valid_task_triple(),
+        participants in valid_participants(device_limit, shares_limit),
+        attempts in 0..5u32, // TODO: Review arbitrary bound on attempts
+        // request in valid_task_request(),  // TODO: Generate valid requests
+    ) -> TaskInfo {
+        TaskInfo {
+            id: Uuid::new_v4(),  // TODO: Should we randomize UUIDs?
+            name,
+            task_type,
+            protocol_type,
+            key_type,
+            participants,
+            attempts,
+            request: Vec::new(),
+        }
+    }
+}
+
+fn valid_group(task_info: &TaskInfo, threshold: u32) -> impl Strategy<Value = Group> {
+    let protocol_type = task_info.protocol_type;
+    let key_type = task_info.key_type;
+    let participant_ids_shares: Vec<(Vec<u8>, u32)> = task_info
+        .participants
+        .iter()
+        .map(|participant| (participant.device.id.clone(), participant.shares))
+        .collect();
+    (".*", prop::option::of(".*")).prop_map(move |(name, note)| {
+        Group {
+            id: Vec::new(), // TODO: Generate valid group ID (public keys)
+            name,
+            threshold: threshold as i32,
+            protocol: protocol_type,
+            key_type,
+            certificate: None, // TODO: Generate valid certificate
+            note,
+            participant_ids_shares: participant_ids_shares.clone(),
+        }
+    })
+}
+
+fn valid_running_task_context(
+    task_info: &TaskInfo,
+    accept_threshold: u32,
+) -> BoxedStrategy<RunningTaskContext> {
+    match task_info.task_type {
+        TaskType::Group => prop::option::of(".*")
+            .prop_map(move |note| RunningTaskContext::Group {
+                threshold: accept_threshold,
+                note,
+            })
+            .boxed(),
+        TaskType::SignPdf => valid_group(task_info, accept_threshold)
+            .prop_map(|group| {
+                RunningTaskContext::SignPdf {
+                    group,
+                    data: Vec::new(), // TODO: Generate valid task data
+                }
+            })
+            .boxed(),
+        TaskType::SignChallenge => valid_group(task_info, accept_threshold)
+            .prop_map(|group| {
+                RunningTaskContext::SignChallenge {
+                    group,
+                    data: Vec::new(), // TODO: Generate valid task data
+                }
+            })
+            .boxed(),
+        TaskType::Decrypt => valid_group(task_info, accept_threshold)
+            .prop_map(|group| {
+                RunningTaskContext::Decrypt {
+                    group,
+                    data: Vec::new(), // TODO: Generate valid task data
+                }
+            })
+            .boxed(),
+    }
+}
+
+fn voting_task_decisions(
+    task_info: &TaskInfo,
+    accept_threshold: u32,
+) -> impl Strategy<Value = HashMap<Vec<u8>, i8>> {
+    // If the accumulated shares of accepting participants exceed the accept threshold,
+    // the task is accepted and thus not voting. We need to limit the accepting participants.
+    // To avoid `prop_filter`, we randomly shuffle the participants, and keep only
+    // the longest prefix whose total shares cannot exceed the threshold,
+    // even if all of them accept.
+    let shuffled_participants = Just(task_info.participants.clone()).prop_shuffle();
+    (shuffled_participants).prop_flat_map(move |shuffled_participants| {
+        // A set of participants with fewer total shares than the accept threshold
+        let potential_voters: Vec<Participant> = shuffled_participants
+            .into_iter()
+            .scan(0, |acc_shares, participant| {
+                *acc_shares += participant.shares;
+                if *acc_shares < accept_threshold {
+                    Some(participant)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Generate a subset of the potential voters
+        let voter_indices = range_subset::range_subset(
+            0..potential_voters.len(),  // NOTE: From indices 0..n_potential_voters
+            0..=potential_voters.len(), //       we select 0 up to n_potential_voters
+        );
+        // Generate arbitrary decisions for the voters
+        let votes =
+            prop::collection::vec(prop_oneof![Just(true), Just(false)], potential_voters.len());
+        (voter_indices, votes).prop_map(move |(voter_indices, votes)| {
+            voter_indices
+                .into_iter()
+                .map(|voter_idx| {
+                    let participant = &potential_voters[voter_idx];
+                    let accepted = votes[voter_idx];
+                    let vote = if accepted {
+                        participant.shares as i8
+                    } else {
+                        -(participant.shares as i8)
+                    };
+                    (participant.device.id.clone(), vote)
+                })
+                .collect()
+        })
+    })
+}
+
+/// Proptest strategy to generate a valid voting task
+pub fn valid_voting_task(
+    device_limit: usize,
+    shares_limit: u32,
+) -> impl Strategy<Value = VotingTask> {
+    valid_task_info(device_limit, shares_limit).prop_flat_map(move |task_info| {
+        let total_shares = task_info.total_shares();
+        let min_accept_threshold = match task_info.task_type {
+            TaskType::Group => total_shares,
+            _ => 1,
+        };
+        // Just like when creating a task in the client, we first specify
+        // the accept threshold, which is implicitly `total_shares` for group tasks
+        (min_accept_threshold..=total_shares).prop_flat_map({
+            let task_info = task_info.clone();
+            move |accept_threshold| {
+                (
+                    voting_task_decisions(&task_info, accept_threshold),
+                    valid_running_task_context(&task_info, accept_threshold),
+                )
+                    .prop_map({
+                        let task_info = task_info.clone();
+                        move |(decisions, running_task_context)| VotingTask {
+                            task_info: task_info.clone(),
+                            decisions,
+                            accept_threshold,
+                            running_task_context,
+                        }
+                    })
+            }
+        })
+    })
+}
+
+fn declined_task_decisions(
+    task_info: &TaskInfo,
+    accept_threshold: u32,
+) -> impl Strategy<Value = HashMap<Vec<u8>, i8>> {
+    // The task is declined if it becomes impossible to accept the task even if all undecided
+    // participants accepted. We calculate the minimum amount of rejects and let the others
+    // decide randomly.
+    // To avoid `prop_filter`, we randomly shuffle the participants, and find the longest
+    // prefix whose total shares cannot exceed the threshold, even if all of them accept.
+    // The rest must reject, but this prefix can decide arbitrarily.
+    let shuffled_participants = Just(task_info.participants.clone()).prop_shuffle();
+    (shuffled_participants).prop_flat_map(move |shuffled_participants| {
+        // A set of participants with fewer total shares than the accept threshold
+        let arbitrary_voters: Vec<Participant> = shuffled_participants
+            .iter()
+            .cloned()
+            .scan(0, |acc_shares, participant| {
+                *acc_shares += participant.shares;
+                if *acc_shares < accept_threshold {
+                    Some(participant)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // The participants which need to reject for the task to be declined
+        let rejecting_voters = &shuffled_participants[arbitrary_voters.len()..];
+
+        let rejecting_decisions: HashMap<_, _> = rejecting_voters
+            .into_iter()
+            .map(|participant| (participant.device.id.clone(), -(participant.shares as i8)))
+            .collect();
+
+        // Generate a subset of the arbitrary voters, representing those who actually vote
+        let voter_indices = range_subset::range_subset(
+            0..arbitrary_voters.len(),  // NOTE: From indices 0..n_arbitrary_voters
+            0..=arbitrary_voters.len(), //       we select 0 up to n_arbitrary_voters
+        );
+        // Generate arbitrary decisions for the voters
+        let votes =
+            prop::collection::vec(prop_oneof![Just(true), Just(false)], arbitrary_voters.len());
+        (voter_indices, votes).prop_map({
+            let rejecting_decisions = rejecting_decisions.clone();
+            move |(voter_indices, votes)| {
+                let mut rejecting_decisions = rejecting_decisions.clone();
+                let arbitrary_votes = voter_indices.into_iter().map(|voter_idx| {
+                    let participant = &arbitrary_voters[voter_idx];
+                    let accepted = votes[voter_idx];
+                    let vote = if accepted {
+                        participant.shares as i8
+                    } else {
+                        -(participant.shares as i8)
+                    };
+                    (participant.device.id.clone(), vote)
+                });
+                rejecting_decisions.extend(arbitrary_votes);
+                rejecting_decisions
+            }
+        })
+    })
+}
+
+/// Proptest strategy to generate a valid declined task
+pub fn valid_declined_task(
+    device_limit: usize,
+    shares_limit: u32,
+) -> impl Strategy<Value = DeclinedTask> {
+    valid_task_info(device_limit, shares_limit).prop_flat_map(|task_info| {
+        let total_shares = task_info.total_shares();
+        (1..=total_shares).prop_flat_map(move |accept_threshold| {
+            declined_task_decisions(&task_info, accept_threshold).prop_map({
+                let task_info = task_info.clone();
+                move |decisions| {
+                    let accepts = decisions.values().filter(|&vote| *vote > 0).count() as u32;
+                    let rejects = decisions.values().filter(|&vote| *vote < 0).count() as u32;
+                    DeclinedTask {
+                        task_info: task_info.clone(),
+                        accepts,
+                        rejects,
+                    }
+                }
+            })
+        })
+    })
+}
+
+prop_compose! {
+    /// Proptest strategy to generate a valid failed task
+    pub fn valid_failed_task(device_limit: usize, shares_limit: u32)(
+        task_info in valid_task_info(device_limit, shares_limit),
+        // TODO: Generate random failure reason
+    ) -> FailedTask {
+        FailedTask { task_info, reason: "".to_string() }
+    }
+}
+
+/// Proptest strategy to generate a valid finished task
+pub fn valid_finished_task(
+    device_limit: usize,
+    shares_limit: u32,
+) -> impl Strategy<Value = FinishedTask> {
+    valid_task_info(device_limit, shares_limit).prop_flat_map(|task_info| {
+        let n_participants = task_info.participants.len();
+        let acknowledging_indices = range_subset::range_subset(
+            0..n_participants,  // NOTE: From indices 0..n_participants
+            0..=n_participants, //       we select 0 up to n_participants
+        );
+        let result = match task_info.task_type {
+            TaskType::Group => (1..=task_info.total_shares())
+                .prop_flat_map({
+                    let task_info = task_info.clone();
+                    move |threshold| {
+                        valid_group(&task_info, threshold).prop_map(TaskResult::GroupEstablished)
+                    }
+                })
+                .boxed(),
+            TaskType::SignChallenge => {
+                Just(TaskResult::Signed(Vec::new())).boxed() // TODO: Generate payload
+            }
+            TaskType::SignPdf => {
+                Just(TaskResult::SignedPdf(Vec::new())).boxed() // TODO: Generate payload
+            }
+            TaskType::Decrypt => {
+                Just(TaskResult::Decrypted(Vec::new())).boxed() // TODO: Generate payload
+            }
+        };
+        (acknowledging_indices, result).prop_map({
+            let task_info = task_info.clone();
+            move |(acknowledging_indices, result)| {
+                let acknowledgements = acknowledging_indices
+                    .into_iter()
+                    .map(|idx| task_info.participants[idx].device.id.clone())
+                    .collect();
+                FinishedTask {
+                    task_info: task_info.clone(),
+                    result,
+                    acknowledgements,
+                }
+            }
+        })
+    })
+}
+
+/// Proptest strategy to generate a valid non-voting task
+pub fn valid_nonvoting_task(device_limit: usize, shares_limit: u32) -> impl Strategy<Value = Task> {
+    prop_oneof![
+        valid_declined_task(device_limit, shares_limit).prop_map(Task::Declined),
+        valid_failed_task(device_limit, shares_limit).prop_map(Task::Failed),
+        valid_finished_task(device_limit, shares_limit).prop_map(Task::Finished),
+        // TODO: Add running task
+    ]
+}

--- a/src/tasks/proptest.rs
+++ b/src/tasks/proptest.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 use std::collections::HashMap;
 
 use super::{
-    DeclinedTask, FailedTask, FinishedTask, RunningTaskContext, Task, TaskInfo, TaskResult,
-    VotingTask,
+    DecisionUpdate, DeclinedTask, FailedTask, FinishedTask, RunningTask, RunningTaskContext, Task,
+    TaskInfo, TaskResult, VotingTask,
 };
 use crate::persistence::{Device, DeviceKind, Group, KeyType, Participant, ProtocolType, TaskType};
 
@@ -278,6 +278,47 @@ pub fn valid_voting_task(
         .prop_flat_map(|task_info| task_info_to_valid_voting_task(task_info))
 }
 
+/// Proptest strategy to generate a valid running task that was just started
+pub fn valid_started_running_task(
+    device_limit: usize,
+    shares_limit: u32,
+) -> impl Strategy<Value = Box<dyn RunningTask>> {
+    valid_task_info(device_limit, shares_limit)
+        .prop_flat_map(|task_info| task_info_to_valid_started_running_task(task_info))
+}
+
+fn task_info_to_valid_started_running_task(
+    task_info: TaskInfo,
+) -> impl Strategy<Value = Box<dyn RunningTask>> {
+    let shuffled_participants = Just(task_info.participants.clone()).prop_shuffle();
+    (
+        shuffled_participants,
+        task_info_to_valid_voting_task(task_info),
+    )
+        .prop_map(|(shuffled_participants, mut voting_task)| {
+            // Accept with random participants until the threshold is reached
+            for participant in shuffled_participants {
+                match voting_task.decide(&participant.device.id, true).unwrap() {
+                    DecisionUpdate::Accepted => break,
+                    _ => {}
+                }
+            }
+
+            let active_shares = voting_task.choose_active_shares(|_| true);
+
+            let running_task = voting_task
+                .running_task_context
+                .clone()
+                .create_running_task(&voting_task, active_shares)
+                .expect(&format!(
+                    "generated invalid data for {:?}",
+                    voting_task.task_info
+                ));
+
+            running_task
+        })
+}
+
 fn declined_task_accepts_rejects(
     task_info: &TaskInfo,
     accept_threshold: u32,
@@ -414,7 +455,8 @@ pub fn valid_nonvoting_task(device_limit: usize, shares_limit: u32) -> impl Stra
         valid_declined_task(device_limit, shares_limit).prop_map(Task::Declined),
         valid_failed_task(device_limit, shares_limit).prop_map(Task::Failed),
         valid_finished_task(device_limit, shares_limit).prop_map(Task::Finished),
-        // TODO: Add running task
+        valid_started_running_task(device_limit, shares_limit).prop_map(Task::Running),
+        // TODO: Extend running task
     ]
 }
 

--- a/src/tasks/proptest.rs
+++ b/src/tasks/proptest.rs
@@ -19,6 +19,13 @@ prop_compose! {
     }
 }
 
+/// Proptest strategy to generate a valid task name
+pub fn valid_task_name() -> impl Strategy<Value = String> {
+    // NOTE: The regex matches arbitrary strings of 0-256 characters,
+    //       excluding unicode control characters
+    r"[^\p{Cc}]{0,256}".prop_filter("<= 256 bytes", |name| name.len() <= 256)
+}
+
 prop_compose! {
     /// Proptest strategy to generate a valid set of participants
     pub fn valid_participants(device_limit: usize, shares_limit: u32)(n_devices in 2..device_limit)(
@@ -79,7 +86,7 @@ pub fn valid_task_triple() -> impl Strategy<Value = (TaskType, ProtocolType, Key
 prop_compose! {
     /// Proptest strategy to generate a valid task info
     pub fn valid_task_info(device_limit: usize, shares_limit: u32)(
-        name in ".*",
+        name in valid_task_name(),
         (task_type, protocol_type, key_type) in valid_task_triple(),
         participants in valid_participants(device_limit, shares_limit),
         attempts in 0..5u32, // TODO: Review arbitrary bound on attempts
@@ -238,7 +245,7 @@ pub fn task_info_to_valid_voting_task(task_info: TaskInfo) -> impl Strategy<Valu
     let total_shares = task_info.total_shares();
     let min_accept_threshold = match task_info.task_type {
         TaskType::Group => total_shares,
-        _ => 1,
+        _ => 2,
     };
     // Just like when creating a task in the client, we first specify
     // the accept threshold, which is implicitly `total_shares` for group tasks
@@ -331,7 +338,7 @@ pub fn valid_declined_task(
 ) -> impl Strategy<Value = DeclinedTask> {
     valid_task_info(device_limit, shares_limit).prop_flat_map(|task_info| {
         let total_shares = task_info.total_shares();
-        (1..=total_shares).prop_flat_map(move |accept_threshold| {
+        (2..=total_shares).prop_flat_map(move |accept_threshold| {
             declined_task_accepts_rejects(&task_info, accept_threshold).prop_map({
                 let task_info = task_info.clone();
                 move |(accepts, rejects)| DeclinedTask {


### PR DESCRIPTION
This PR adds support for property testing using the [proptest](https://github.com/proptest-rs/proptest) crate. It introduces strategies for generating arbitrary instances of various kinds of Tasks and adds several tests for correctness of the strategies and algorithmically heavy parts of the codebase. Finally, this PR also closes #54 and adds an example property test for such fixes.